### PR TITLE
CAB-3042: Add metrics from SpringBoot2 applications to grafana

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,6 @@ sourceCompatibility = 1.8
 ext {
     gwsClientVersion = "0.0.1"
 }
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.5.1'
-}
 
 repositories {
     jcenter()
@@ -65,8 +62,8 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-actuator")
     compile("org.springframework.boot:spring-boot-starter-hateoas")
     compile('org.springframework.boot:spring-boot-starter-cache')
-    compile('io.micrometer:micrometer-registry-statsd:latest.release')
-    runtime("org.pcollections:pcollections:3.0.1") // required for micrometer, expected fix in micrometer v1.0.6
+    compile('io.micrometer:micrometer-registry-statsd')
+
 
     compile("org.springframework.cloud:spring-cloud-starter-aws")
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.0.3.RELEASE'
+        springBootVersion = '2.1.6.RELEASE'
         springCloudReleaseTrain = 'Finchley.SR2'
     }
     repositories {
@@ -40,7 +40,7 @@ ext {
     gwsClientVersion = "0.0.1"
 }
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.2.1'
+    gradleVersion = '4.5.1'
 }
 
 repositories {
@@ -65,7 +65,8 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-actuator")
     compile("org.springframework.boot:spring-boot-starter-hateoas")
     compile('org.springframework.boot:spring-boot-starter-cache')
-
+    compile('io.micrometer:micrometer-registry-statsd:latest.release')
+    runtime("org.pcollections:pcollections:3.0.1") // required for micrometer, expected fix in micrometer v1.0.6
 
     compile("org.springframework.cloud:spring-cloud-starter-aws")
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.6.RELEASE'
+        springBootVersion = '2.0.3.RELEASE'
         springCloudReleaseTrain = 'Finchley.SR2'
     }
     repositories {
@@ -63,6 +63,7 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-hateoas")
     compile('org.springframework.boot:spring-boot-starter-cache')
     compile('io.micrometer:micrometer-registry-statsd')
+    runtime("org.pcollections:pcollections:3.0.1") // required for micrometer, expected fix in micrometer v1.0.6 (upgrading spring may fix this)
 
 
     compile("org.springframework.cloud:spring-cloud-starter-aws")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip

--- a/src/main/java/edu/uw/edm/profile/config/AuthenticationConfiguration.java
+++ b/src/main/java/edu/uw/edm/profile/config/AuthenticationConfiguration.java
@@ -66,7 +66,7 @@ public class AuthenticationConfiguration {
             http.csrf().disable();
 
             http.authorizeRequests()
-                    .requestMatchers(EndpointRequest.to("status", "info", "health"))
+                    .requestMatchers(EndpointRequest.toAnyEndpoint())
                         .permitAll()
                     .antMatchers("/docs/**")
                         .permitAll()


### PR DESCRIPTION
- upgrade gradle version
- allow access to any endpoint rather than limiting to 'status','info','health'