### PR TITLE
CAB-4161: upgrade references to GWS Client for release 1.0.0

### DIFF
--- a/src/main/java/edu/uw/edm/profile/config/GeneralConfiguration.java
+++ b/src/main/java/edu/uw/edm/profile/config/GeneralConfiguration.java
@@ -46,7 +46,7 @@ public class GeneralConfiguration {
     }
 
     @Bean
-    public PoolingHttpClientConnectionManager connectionManager(final KeyManagerCabinet cabinet) throws KeyManagementException, NoSuchAlgorithmException {
+    public PoolingHttpClientConnectionManager connectionManager(@Qualifier("profile-api") final KeyManagerCabinet cabinet) throws KeyManagementException, NoSuchAlgorithmException {
         TrustManager[] trustManagers = cabinet.getTrustManagers();
 
 
@@ -65,7 +65,7 @@ public class GeneralConfiguration {
         return new PoolingHttpClientConnectionManager(sfr);
     }
 
-    @Bean
+    @Bean("profile-api")
     public KeyManagerCabinet keyManagerCabinet(SecurityProperties securityProperties) throws Exception {
         return new KeyManagerCabinet.Builder(securityProperties).build();
     }


### PR DESCRIPTION
- resolve BeanDefinitionOverrideException for KeyManagerCabinet with definition in GWS client

GWS Client v0.0.2 introduced a KeyManagerCabinet bean which conflicted with Profile-API's existing KeyManagerCabinet bean.

Spring 2.1 disabled [bean overriding ]( https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding), which throws a BeanDefinitionOverrideException if there is a collision. 

By qualifying the declaration & usage of the KeyManagerCabinet in Profile-API the conflict has been resolved.