### PR TITLE
CAB-4161: upgrade references to GWS Client for release 1.0.0

### DIFF
--- a/src/main/java/edu/uw/edm/profile/config/GeneralConfiguration.java
+++ b/src/main/java/edu/uw/edm/profile/config/GeneralConfiguration.java
@@ -71,7 +71,7 @@ public class GeneralConfiguration {
     }
 
 
-    @Bean
+    @Bean("profile-api")
     @Primary
     public RestTemplate restTemplate(@Qualifier("httpClient") HttpClient httpClient) {
         return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));


### PR DESCRIPTION
- resolve BeanDefinitionOverrideException for RestTemplate with the definition in GWS client. A previous commit ( c968a582783f7c642b8803a5413f55c2996f4a54 ) resolved the problem with the KeyManaggerCabinet, however, missed updating the RestTemplate bean.

GWS Client v0.0.2 introduced a RestTemplate bean which conflicted with Profile-API's existing RestTemplate bean.

Spring 2.1 disabled [bean overriding ]( https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding), which throws a BeanDefinitionOverrideException if there is a collision.

By qualifying the declaration & usage of the RestTemplate in Profile-API the conflict has been resolved.